### PR TITLE
Fixes for metanorma-acme reference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}" }
 
 gemspec
-# TODO: move to gemspec
-gem 'metanorma-acme', git: 'https://github.com/metanorma/metanorma-acme.git'
 
 if File.exist? 'Gemfile.devel'
   eval File.read('Gemfile.devel'), nil, 'Gemfile.devel' # rubocop:disable Security/Eval

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}" }
 
 gemspec
 # TODO: move to gemspec
-gem 'metanorma-acme',
-  git: 'https://github.com/metanorma/metanorma-acme.git',
-  branch: 'feature/rng-file-configuration-option'
+gem 'metanorma-acme', git: 'https://github.com/metanorma/metanorma-acme.git'
 
 if File.exist? 'Gemfile.devel'
   eval File.read('Gemfile.devel'), nil, 'Gemfile.devel' # rubocop:disable Security/Eval

--- a/lib/asciidoctor/vsd/converter.rb
+++ b/lib/asciidoctor/vsd/converter.rb
@@ -12,6 +12,18 @@ module Asciidoctor
       def configuration
         Metanorma::Vsd.configuration
       end
+
+      def html_converter(node)
+        IsoDoc::Vsd::HtmlConvert.new(html_extract_attributes(node))
+      end
+
+      def pdf_converter(node)
+        IsoDoc::Vsd::PdfConvert.new(html_extract_attributes(node))
+      end
+
+      def word_converter(node)
+        IsoDoc::Vsd::WordConvert.new(doc_extract_attributes(node))
+      end
     end
   end
 end

--- a/metanorma-vsd.gemspec
+++ b/metanorma-vsd.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "htmlentities", "~> 4.3.4"
   #spec.add_dependency "nokogiri"
   spec.add_dependency "metanorma-iso", "~> 1.3.0"
-  #spec.add_dependency "metanorma"
+  spec.add_dependency "metanorma-acme", "~> 1.4.0"
   spec.add_dependency "isodoc", "~> 1.0.0"
 
   spec.add_development_dependency "byebug", "~> 9.1"

--- a/spec/metanorma/vsd_spec.rb
+++ b/spec/metanorma/vsd_spec.rb
@@ -33,24 +33,16 @@ RSpec.describe Metanorma::Vsd do
       let(:organization_name_short) { 'Test' }
       let(:organization_name_long) { 'Test Corp.' }
       let(:document_namespace) { 'https://example.com/' }
-      let(:html_extract_attributes) do
-        {
-          'one' => 'sting',
-          'two' => 'number'
-        }
-      end
 
       it 'sets atrributes' do
         Metanorma::Vsd.configure do |config|
           config.organization_name_short = organization_name_short
           config.organization_name_long = organization_name_long
           config.document_namespace = document_namespace
-          config.html_extract_attributes = html_extract_attributes
         end
         expect(config.organization_name_short).to eq(organization_name_short)
         expect(config.organization_name_long).to eq(organization_name_long)
         expect(config.document_namespace).to eq(document_namespace)
-        expect(config.html_extract_attributes).to eq(html_extract_attributes)
       end
     end
   end


### PR DESCRIPTION
metanorma/metanorma-vsd#4:

Fixed wrong branch reference metanorma-acme, changed converters for vsd::converters to use vsd specific converters instead of metanorma-acme