### PR TITLE
Hotfix wrong rng file path in configuration.

### DIFF
--- a/lib/metanorma/vsd.rb
+++ b/lib/metanorma/vsd.rb
@@ -33,7 +33,7 @@ module Metanorma
         self.scripts ||= File.join(isodoc_vsd_html_folder, 'scripts.html')
         self.logo_path ||= File.join(isodoc_vsd_html_folder, 'logo.png')
         self.xml_root_tag ||= 'vsd-standard'
-        vsd_rng_folder ||= File.join(File.expand_path('asciidoctor', __dir__), 'vsd')
+        vsd_rng_folder ||= File.join(File.expand_path('../asciidoctor', __dir__), 'vsd')
         self.validate_rng_file ||= File.join(vsd_rng_folder, 'vsd.rng')
         super
       end


### PR DESCRIPTION
@opoudjis @ronaldtse found this error during metanorma-rsd specs fix, we dont have specs for validation in this repo so i have missed this error.