### PR TITLE
HTML docstage/doctype layout conflict fix

### DIFF
--- a/lib/isodoc/vsd/html/htmlstyle.scss
+++ b/lib/isodoc/vsd/html/htmlstyle.scss
@@ -125,10 +125,6 @@ p.document-stage {
   height: 160px;
 }
 
-#standard-band p {
-  height: 270px;
-}
-
 #proposal-band p {
   height: 150px;
 }

--- a/lib/isodoc/vsd/html/htmlstyle.scss
+++ b/lib/isodoc/vsd/html/htmlstyle.scss
@@ -97,7 +97,11 @@ div.figure {
 */
 
 .document-type-band {
-  @include docBand(2, 150, 180px);
+  @include docBand($order: 2, $offset: 180px);
+
+  .document-type {
+    top: 20px;
+  }
 }
 
 .document-stage-band {
@@ -108,7 +112,6 @@ div.figure {
   font-weight: 300;
 }
 
-p.document-type,
 p.document-stage {
   @include docBandTitle(150);
 }


### PR DESCRIPTION
metanorma/metanorma-ogc#128:

HTML docstage/doctype layout conflict fix,
Use new format docBand isodoc mixin