### PR TITLE
XML file when directly passed to Metanorma displays error message

### DIFF
--- a/lib/asciidoctor/vsd/converter.rb
+++ b/lib/asciidoctor/vsd/converter.rb
@@ -7,6 +7,8 @@ module Asciidoctor
     # schema encapsulation of the document for validation
     #
     class Converter < Asciidoctor::Generic::Converter
+      XML_ROOT_TAG = Metanorma::Vsd.configuration.xml_root_tag
+
       register_for "vsd"
 
       def configuration

--- a/spec/metanorma/vsd_spec.rb
+++ b/spec/metanorma/vsd_spec.rb
@@ -45,5 +45,9 @@ RSpec.describe Metanorma::Vsd do
         expect(config.document_namespace).to eq(document_namespace)
       end
     end
+
+    it 'Asciidoctor::Vsd::Converter::XML_ROOT_TAG has the correct value' do
+      expect(Asciidoctor::Vsd::Converter::XML_ROOT_TAG).to eq('vsd-standard')
+    end
   end
 end


### PR DESCRIPTION
metanorma/metanorma-rsd#55:

    Fixed error with missing root_tag in metanorma registry when flavour is loaded